### PR TITLE
Helper text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ db/cms_fixtures/test-site/
 /node_modules
 /app/assets/builds/*
 !/app/assets/builds/.keep
+docs

--- a/app/views/layouts/comfy/admin/cms/_left.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_left.html.haml
@@ -35,7 +35,7 @@
 = comfy_admin_partial "comfy/admin/cms/partials/navigation_after"
 
 .left-footer
-  = link_to 'ComfortableMediaSurfer', 'https://github.com/shakacode/comfortable-media-surfer', target: '_blank'
+  = link_to "ComfortableMediaSurfer - Pete's version", 'https://github.com/petealbertson/comfortable-media-surfer', target: '_blank'
   %span.version= ComfortableMediaSurfer::VERSION
   %br
   = link_to 'Rails', 'https://rubyonrails.org', target: '_blank'

--- a/lib/comfortable_media_surfer/form_builder.rb
+++ b/lib/comfortable_media_surfer/form_builder.rb
@@ -7,6 +7,7 @@ class ComfortableMediaSurfer::FormBuilder < ComfyBootstrapForm::FormBuilder
   # @param [ComfortableMediaSurfer::Content::Tag] tag
   # @param [Integer] index
   def fragment_field(tag, index)
+    helper_text = tag.options['helper_text']
     tag.form_field(object_name, @template, index) do |tag_input|
       name = "#{object_name}[fragments_attributes][#{index}][identifier]"
       identifer_input = @template.hidden_field_tag(name, tag.identifier, id: nil)
@@ -22,6 +23,10 @@ class ComfortableMediaSurfer::FormBuilder < ComfyBootstrapForm::FormBuilder
         concat identifer_input
         concat tag_name_input
         concat tag_input
+        # Render helper text if present
+        if helper_text.present?
+          concat @template.content_tag(:p, helper_text, class: 'text-muted')
+        end
       end
     end
   end

--- a/lib/comfortable_media_surfer/seeds/page/importer.rb
+++ b/lib/comfortable_media_surfer/seeds/page/importer.rb
@@ -186,18 +186,18 @@ module ComfortableMediaSurfer::Seeds::Page
     # ActiveStorage and a list of ids of old attachements to destroy
     def files_content(record, identifier, path, frag_content)
       # preparing attachments
-      if frag_content.nil?
-        files = []
-      else
-        files = frag_content.split("\n").collect do |filename|
-          file_handler = File.open(File.join(path, filename))
-          {
-            io: file_handler,
-            filename: filename,
-            content_type: MimeMagic.by_magic(file_handler)
-          }
-        end
-      end
+      files = if frag_content.nil?
+                []
+              else
+                frag_content.split("\n").collect do |filename|
+                  file_handler = File.open(File.join(path, filename))
+                  {
+                    io: file_handler,
+                    filename: filename,
+                    content_type: MimeMagic.by_magic(file_handler)
+                  }
+                end
+              end
 
       # ensuring that old attachments get removed
       ids_destroy = []


### PR DESCRIPTION
### Summary

When adding fields to a layout, you can now use `{{ cms:text headline helper_text: "Some useful input advice" }}` to add a caption beneath the field input. It's limited to 240 characters.