### PR TITLE
Sync with upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'byebug',             '~> 12.0.0', platforms: %i[mri mingw x64_mingw]
   gem 'gem-release'
   gem 'image_processing',   '>= 1.12.0'
-  gem 'propshaft',          '~> 1.2.1'
+  gem 'propshaft',          '~> 1.3.1'
   gem 'sqlite3',            '>= 2.1'
   # gem 'mysql2',             '~> 0.5'
   # gem 'pg',                 '~> 1.5.4'

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
   gem 'ostruct'
   gem 'puma'
   gem 'rails-controller-testing', '~> 1.0.5'
-  gem 'rubocop',                  '~> 1.80.1', require: false
+  gem 'rubocop',                  '~> 1.81.1', require: false
   gem 'rubocop-minitest'
   gem 'rubocop-rails'
   gem 'simplecov', '~> 0.22.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
   gem 'ostruct'
   gem 'puma'
   gem 'rails-controller-testing', '~> 1.0.5'
-  gem 'rubocop',                  '~> 1.77.0', require: false
+  gem 'rubocop',                  '~> 1.80.1', require: false
   gem 'rubocop-minitest'
   gem 'rubocop-rails'
   gem 'simplecov', '~> 0.22.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
 end
 
 group :test do
-  gem 'brakeman',                 '~> 7.0.2'
+  gem 'brakeman',                 '~> 7.1.0'
   gem 'bundler-audit',            '~> 0.9.1'
   gem 'coveralls_reborn',         '~> 0.29.0', require: false
   gem 'cuprite',                  '>= 0.15'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem 'byebug',             '~> 12.0.0', platforms: %i[mri mingw x64_mingw]
   gem 'gem-release'
   gem 'image_processing',   '>= 1.12.0'
-  gem 'propshaft',          '~> 1.1.0'
+  gem 'propshaft',          '~> 1.2.1'
   gem 'sqlite3',            '>= 2.1'
   # gem 'mysql2',             '~> 0.5'
   # gem 'pg',                 '~> 1.5.4'

--- a/comfortable_media_surfer.gemspec
+++ b/comfortable_media_surfer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'active_link_to',       '~> 1.0',   '>= 1.0.5'
   spec.add_dependency 'comfy_bootstrap_form', '~> 4.0',   '>= 4.0.0'
-  spec.add_dependency 'haml-rails',           '~> 2.1',   '>= 2.1.0'
+  spec.add_dependency 'haml-rails',           '>= 2.1', '< 4.0'
   spec.add_dependency 'image_processing',     '~> 1.2',   '>= 1.12.2'
   spec.add_dependency 'kaminari',             '~> 1.2',   '>= 1.2.2'
   spec.add_dependency 'kramdown',             '~> 2.4',   '>= 2.4.0'


### PR DESCRIPTION
This pull request updates several gem dependencies to newer versions in both the `Gemfile` and the gemspec file. These updates help ensure compatibility, security, and access to the latest features and bug fixes.

Dependency version updates:

**Development and test dependencies:**
* Updated `propshaft` gem from `~> 1.1.0` to `~> 1.3.1` in the `Gemfile` to use a newer version for asset pipeline management.
* Updated `brakeman` gem from `~> 7.0.2` to `~> 7.1.0` in the `Gemfile` for improved static analysis and security checks.
* Updated `rubocop` gem from `~> 1.77.0` to `~> 1.81.1` in the `Gemfile` for the latest linting and code style checks.

**Runtime dependencies:**
* Relaxed the `haml-rails` dependency in `comfortable_media_surfer.gemspec` from `'~> 2.1', '>= 2.1.0'` to `'>= 2.1', '< 4.0'`, allowing for greater flexibility and compatibility with future `haml-rails` versions up to but not including 4.0.### Summary

General information about what this PR is all about. If it fixes any issues
please don't forget to tag them.

Thanks for contributing!
