### PR TITLE
Wrap iframe output in responsive container div

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/extensions/iframe.js
+++ b/app/assets/javascripts/comfy/admin/cms/extensions/iframe.js
@@ -55,7 +55,7 @@ const Iframe = Node.create({
     }
     classes.add(IFRAME_CLASS);
     merged.class = Array.from(classes).join(" ");
-    return ["iframe", merged];
+    return ["div", { class: "cms-iframe-responsive" }, ["iframe", merged]];
   },
   renderText({ node }) {
     const attrs = node.attrs.htmlAttributes || {};


### PR DESCRIPTION
## Problem

When editing raw HTML in the Rhino WYSIWYG editor, any `<div>` wrapper around an `<iframe>` gets stripped on Apply. This is because TipTap's `setContent()` only preserves elements with registered schema nodes, and there is no `div` node.

This means content admins cannot add the responsive wrapper div needed for proper iframe embed sizing (e.g. the `padding-top` aspect ratio trick).

## Solution

Modify the IframeExtension's `renderHTML` to automatically wrap the `<iframe>` in a `<div class="cms-iframe-responsive">` container.

```html
<div class="cms-iframe-responsive">
  <iframe src="..." class="cms-rhino-iframe" ...></iframe>
</div>
```

### Why this works

- **Output (`getHTML()`):** Emits the wrapper div → stored in DB → rendered on front-end with the responsive container
- **Input (`setContent()`):** `parseHTML` still matches just `tag: "iframe"`, so the wrapper div is transparent on re-parse — round-trips cleanly
- **Admin experience:** Paste an `<iframe>`, it just works. No manual HTML/CSS needed.

### Host app responsibility

The host app provides the CSS for `.cms-iframe-responsive` to achieve the desired responsive sizing, e.g.:

```css
.cms-iframe-responsive {
  position: relative;
  padding-top: max(60%, 326px);
  height: 0;
  width: 100%;
}
.cms-iframe-responsive iframe {
  position: absolute;
  top: 0;
  left: 0;
  width: 100%;
  height: 100%;
  border: 0;
}
```